### PR TITLE
Fixed output file not changing with trigger commands

### DIFF
--- a/host/dataprocessor.cpp
+++ b/host/dataprocessor.cpp
@@ -16,7 +16,7 @@ DataProcessor::DataProcessor(boost::mutex *m, std::queue<boost::shared_array<uns
 {
     mQueue = m;
     dQueue = d;
-    status = 0;
+    status = RUNNING;
     cur_time = 0;
     doAccumulation = false;
     last_tick = 0;
@@ -39,10 +39,10 @@ void DataProcessor::operator()()
     int t1, t2;
 
     t1 = time(0);
-    while(status == 0 || !isEmpty)
+    while(status == RUNNING || !isEmpty)
     {
         getData();
-        if(status != 0 && isEmpty)
+        if(status != RUNNING && isEmpty)
             continue;
         processData();
         // printf("gda\n");
@@ -78,7 +78,7 @@ void DataProcessor::getData()
             isEmpty = true;
         }
         sleep(1);
-    } while(status == 0);
+    } while(status == RUNNING);
 
 }
 
@@ -157,7 +157,7 @@ void DataProcessor::processData()
 
 void DataProcessor::endSignal()
 {
-    status = 1;
+    status = IDLE;
 }
 
 
@@ -189,7 +189,7 @@ float DataProcessor::convertToPower(float v)
 
 int DataProcessor::closeOutput()
 {
-    if (status == 1)
+    if (status == RUNNING)
     {
         return 1;
     }

--- a/host/dataprocessor.h
+++ b/host/dataprocessor.h
@@ -33,6 +33,11 @@ public:
     int openOutput(std::string output_loc);
     int openedFile();
 private:
+    enum RunningStatus {
+        RUNNING,
+        IDLE
+    };
+
     boost::mutex *mQueue;
     std::queue<boost::shared_array<unsigned char> > *dQueue;
     boost::shared_array<unsigned char> data;

--- a/host/dataprocessor.h
+++ b/host/dataprocessor.h
@@ -11,6 +11,8 @@
 #include <boost/accumulators/statistics/min.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 
+#include "libusbinterface.h"
+
 #define TIMER_SECOND_TICKS      84000000
 
 namespace _ba =  boost::accumulators;
@@ -18,7 +20,7 @@ namespace _ba =  boost::accumulators;
 class DataProcessor
 {
 public:
-    DataProcessor(boost::mutex *, std::queue<boost::shared_array<unsigned char> > *);
+    DataProcessor(boost::mutex *, std::queue<DataSet> *);
     ~DataProcessor();
     void operator()();
     void endSignal();
@@ -39,8 +41,8 @@ private:
     };
 
     boost::mutex *mQueue;
-    std::queue<boost::shared_array<unsigned char> > *dQueue;
-    boost::shared_array<unsigned char> data;
+    std::queue<DataSet> *dQueue;
+    DataSet data;
 
     int status;
     bool isEmpty;

--- a/host/libusbinterface.h
+++ b/host/libusbinterface.h
@@ -9,10 +9,20 @@
 
 #define DATA_LEN    2048
 
+enum DataSetType {
+    ENERGY_DATA = 0,
+    COMMAND = 1
+};
+
+struct DataSet {
+    boost::shared_array<unsigned char> data;
+    DataSetType type;
+};
+
 class LibusbInterface
 {
 public:
-    LibusbInterface(boost::mutex *, std::queue<boost::shared_array<unsigned char> > *, unsigned idVendor, unsigned idProduct, std::string serialId);
+    LibusbInterface(boost::mutex *, std::queue<DataSet> *, unsigned idVendor, unsigned idProduct, std::string serialId);
     ~LibusbInterface();
     void operator()();
     void endSignal();
@@ -42,7 +52,7 @@ public:
 private:
     boost::mutex *mQueue;
     boost::mutex cQueueMutex;
-    std::queue<boost::shared_array<unsigned char> > *dQueue;
+    std::queue<DataSet> *dQueue;
 
     // Attributes to look for in the USB devices
     unsigned idProduct, idVendor;
@@ -57,7 +67,7 @@ private:
     void close_device();
 
     // Send data to the data processor thread
-    void send_data(boost::shared_array<unsigned char>);
+    void send_data(DataSet);
 
     int status;
     libusb_device_handle *devh;


### PR DESCRIPTION
Since 36a8870 (pull request #4), results were not being stored if the start command was issued by a LibusbInterface trigger. This pull request fixes that. The output file is still opened and closed with start and stop commands (and now start and stop triggers as well).

(Note: This pull request is still missing the host_receiver.h file that's added in pull request #5)
