### PR TITLE
Classy platformrun

### DIFF
--- a/pyenergy/src/platformrun/platformrun.py
+++ b/pyenergy/src/platformrun/platformrun.py
@@ -3,10 +3,12 @@
 
 Usage:
     platformrun [-v | -vv] [options] PLATFORM EXECUTABLE
+    platformrun -l
     platformrun -h
 
 Options:
     -h --help           Show this usage message
+    -l --list           List available platforms for use in PLATFORM argument
     -c --config CONF    Specify the measurement configuration to load
                             [default: ~/.measurementrc]
     -t --tools CONF     Config file for the tools needed to run on a platform
@@ -19,17 +21,6 @@ Options:
                         measurement points
 
     PLATFORM        Specify the platform on which to run.
-                    Available platforms are:
-                        stm32f0discovery
-                        stm32l0discovery
-                        stm32vldiscovery
-                        stm32f4discovery
-                        atmega328p
-                        xmegaa3buxplained
-                        msp-exp430f5529
-                        msp-exp430fr5739
-                        pic32mx250f128b
-                        sam4lxplained
 
 """
 from docopt import docopt
@@ -338,6 +329,14 @@ class PlatformRun:
 
     #######################################################################
 
+    def listPlatforms(self):
+        print "Available platforms:"
+        print '\n'.join(map(
+            lambda s: ' ' * 4 + s[9:],
+            filter(
+                lambda s: s.startswith('platform_') and
+                callable(getattr(self, s)), dir(self))))
+
     def platform_xmosslicekita16(self, fname, doMeasure=True):
         name = "xmosslicekita16"
         em = self.setupMeasurement(name, doMeasure)
@@ -556,6 +555,10 @@ def main():
         logging.getLogger('').setLevel(logging.DEBUG)
 
     PR = PlatformRun()
+
+    if arguments['--list']:
+        PR.listPlatforms()
+        return
 
     PR.loadConfiguration(arguments['--config'])
     PR.loadToolConfiguration(arguments['--tools'])

--- a/pyenergy/src/platformrun/platformrun.py
+++ b/pyenergy/src/platformrun/platformrun.py
@@ -229,7 +229,7 @@ class PlatformRun:
                 "Command \"{}\" returned {}".format(cmd, proc.exitstatus))
         info("Foreground proc complete")
 
-    def setupMeasurement(platform, doMeasure=True):
+    def setupMeasurement(self, platform, doMeasure=True):
         if not doMeasure:
             return None
 
@@ -260,7 +260,7 @@ class PlatformRun:
 
         return em
 
-    def finishMeasurement(platform, em, doMeasure=True, timeout=30):
+    def finishMeasurement(self, platform, em, doMeasure=True, timeout=30):
         if not doMeasure:
             return None
 
@@ -292,7 +292,7 @@ class PlatformRun:
         return m
 
     # Display units nicer
-    def prettyPrint(v):
+    def prettyPrint(self, v):
         units = [' ', 'm', 'u', 'n', 'p']
 
         for unit in units:
@@ -303,13 +303,13 @@ class PlatformRun:
 
     #######################################################################
 
-    def loadConfiguration(fname="~/.measurementrc"):
+    def loadConfiguration(self, fname="~/.measurementrc"):
         global measurement_config
 
         fname = os.path.expanduser(fname)
         measurement_config = json.load(open(fname))
 
-    def loadToolConfiguration(fname="~/.platformrunrc"):
+    def loadToolConfiguration(self, fname="~/.platformrunrc"):
         global tool_config
 
         fname = os.path.expanduser(fname)
@@ -317,7 +317,7 @@ class PlatformRun:
 
     ##
 
-    def findUSBLocation(devid):
+    def findUSBLocation(self, devid):
         info("Discovering USB bus address of {}".format(devid))
 
         for bus in usb.busses():
@@ -337,8 +337,20 @@ class PlatformRun:
         return ""
 
     #######################################################################
+
     @killBgOnCtrlC
-    def stm32f0discovery(self, fname, doMeasure=True):
+    def platform_xmosslicekita16(self, fname, doMeasure=True):
+        name = "xmosslicekita16"
+        em = self.setupMeasurement(name, doMeasure)
+
+        xrunproc = self.background_proc(tool_config['tools']['xrun'] +
+                                        " --xscope")
+        self.kill_background_proc(xrunproc)
+
+        return self.finishMeasurement(name, em, doMeasure)
+
+    @killBgOnCtrlC
+    def platform_stm32f0discovery(self, fname, doMeasure=True):
         em = self.setupMeasurement("stm32f0discovery", doMeasure)
 
         stproc = self.background_proc(tool_config['tools']['stutil'] +
@@ -349,7 +361,7 @@ class PlatformRun:
         return self.finishMeasurement("stm32f0discovery", em, doMeasure)
 
     @killBgOnCtrlC
-    def stm32vldiscovery(self, fname, doMeasure=True):
+    def platform_stm32vldiscovery(self, fname, doMeasure=True):
         em = self.setupMeasurement("stm32vldiscovery", doMeasure)
 
         stproc = self.background_proc(tool_config['tools']['stutil'] +
@@ -360,7 +372,7 @@ class PlatformRun:
         return self.finishMeasurement("stm32vldiscovery", em, doMeasure)
 
     @killBgOnCtrlC
-    def stm32f4discovery(self, fname, doMeasure=True):
+    def platform_stm32f4discovery(self, fname, doMeasure=True):
         em = self.setupMeasurement("stm32f4discovery", doMeasure)
 
         stproc = self.background_proc(tool_config['tools']['stutil'] +
@@ -371,7 +383,7 @@ class PlatformRun:
         return self.finishMeasurement("stm32f4discovery", em, doMeasure)
 
     @killBgOnCtrlC
-    def stm32l0discovery(self, fname, doMeasure=True):
+    def platform_stm32l0discovery(self, fname, doMeasure=True):
         em = self.setupMeasurement("stm32l0discovery", doMeasure)
 
         stproc = self.background_proc(tool_config['tools']['openocd'] +
@@ -385,7 +397,7 @@ class PlatformRun:
         return self.finishMeasurement("stm32l0discovery", em, doMeasure)
 
     @killBgOnCtrlC
-    def beaglebone(self, fname, doMeasure=True):
+    def platform_beaglebone(self, fname, doMeasure=True):
         em = self.setupMeasurement("beaglebone", doMeasure)
 
         openocdproc = self.background_proc(tool_config['tools']['openocd'] +
@@ -397,7 +409,7 @@ class PlatformRun:
 
         return self.finishMeasurement("beaglebone", em, doMeasure)
 
-    def atmega328p(self, fname, doMeasure=True):
+    def platform_atmega328p(self, fname, doMeasure=True):
         # Create temporary file and convert to hex file
         tf = tempfile.NamedTemporaryFile(delete=False)
         tf.close()
@@ -441,7 +453,7 @@ class PlatformRun:
             pass
         return self.finishMeasurement("atmega328p", em, doMeasure)
 
-    def xmegaa3buxplained(self, fname, doMeasure=True):
+    def platform_xmegaa3buxplained(self, fname, doMeasure=True):
         em = self.setupMeasurement("xmegaa3buxplained", doMeasure)
 
         # Create temporary file and convert to hex file
@@ -468,7 +480,7 @@ class PlatformRun:
             pass
         return self.finishMeasurement("xmegaa3buxplained", em, doMeasure)
 
-    def mspexp430f5529(self, fname, doMeasure=True):
+    def platform_mspexp430f5529(self, fname, doMeasure=True):
         em = self.setupMeasurement("msp-exp430f5529", doMeasure)
 
         self.foreground_proc("{} tilib -q \"prog {}\" &".format(
@@ -476,7 +488,7 @@ class PlatformRun:
 
         return self.finishMeasurement("msp-exp430f5529", em, doMeasure)
 
-    def mspexp430fr5739(self, fname, doMeasure=True):
+    def platform_mspexp430fr5739(self, fname, doMeasure=True):
         em = self.setupMeasurement("msp-exp430fr5739", doMeasure)
 
         self.foreground_proc("{} rf2500 \"prog {}\" &".format(
@@ -484,7 +496,7 @@ class PlatformRun:
 
         return self.finishMeasurement("msp-exp430fr5739", em, doMeasure)
 
-    def pic32mx250f128b(self, fname, doMeasure=True):
+    def platform_pic32mx250f128b(self, fname, doMeasure=True):
         # Create temporary file and convert to hex fil, doMeasuree
         tf = tempfile.NamedTemporaryFile(delete=False)
         tf.close()
@@ -500,7 +512,7 @@ class PlatformRun:
         return self.finishMeasurement("pic32mx250f128b", em, doMeasure)
 
     @killBgOnCtrlC
-    def sam4lxplained(self, fname, doMeasure=True):
+    def platform_sam4lxplained(self, fname, doMeasure=True):
         em = self.setupMeasurement("sam4lxplained", doMeasure)
 
         openocdproc = self.background_proc(
@@ -517,31 +529,12 @@ class PlatformRun:
         if not os.path.isfile(execname):
             raise IOError("File \"{}\" does not exist".format(execname))
 
-        if platformname == "stm32f0discovery":
-            m = self.stm32f0discovery(execname, measurement)
-        elif platformname == "stm32vldiscovery":
-            m = self.stm32vldiscovery(execname, measurement)
-        elif platformname == "stm32f4discovery":
-            m = self.stm32f4discovery(execname, measurement)
-        elif platformname == "stm32l0discovery":
-            m = self.stm32l0discovery(execname, measurement)
-        elif platformname == "beaglebone":
-            m = self.beaglebone(execname, measurement)
-        elif platformname == "atmega328p":
-            m = self.atmega328p(execname, measurement)
-        elif platformname == "xmegaa3buxplained":
-            m = self.xmegaa3buxplained(execname, measurement)
-        elif platformname == "pic32mx250f128b":
-            m = self.pic32mx250f128b(execname, measurement)
-        elif platformname == "msp-exp430f5529":
-            m = self.mspexp430f5529(execname, measurement)
-        elif platformname == "msp-exp430fr5739":
-            m = self.mspexp430fr5739(execname, measurement)
-        elif platformname == "sam4lxplained":
-            m = self.sam4lxplained(execname, measurement)
-        else:
+        mname = 'platform_{}'.format(platformname)
+        attr = getattr(self, mname, None)
+        if not callable(attr):
             raise RuntimeError("Unknown platform " + platformname)
-        return m
+
+        return attr(execname, measurement)
 
     def run_multiple(self, platformname, execname, repeats, measurement=True):
         measurements = []

--- a/pyenergy/src/platformrun/platformrun.py
+++ b/pyenergy/src/platformrun/platformrun.py
@@ -86,7 +86,7 @@ class LogWriter(object):
         pass
 
 
-class PlatformRun():
+class PlatformRun:
     def __init__(self):
         self.bg_procs = []
         self.bg_proc_map = {}

--- a/pyenergy/src/platformrun/platformrun.py
+++ b/pyenergy/src/platformrun/platformrun.py
@@ -60,6 +60,18 @@ measurement_config = None
 #######################################################################
 
 
+def killBgOnCtrlC(f):
+    def wrap(instance, platform, *args, **kwargs):
+        try:
+            return f(instance, platform, *args, **kwargs)
+        except:
+            info("Exception occured, killing background procs")
+            for p in copy.copy(instance.bg_procs):
+                instance.kill_background_proc(p)
+            raise
+    return wrap
+
+
 class CommandError(RuntimeError):
     pass
 
@@ -193,17 +205,6 @@ class PlatformRun:
         self.bg_proc_map[p].join()
         sleep(0.1)
         self.bg_procs.remove(p)
-
-    def killBgOnCtrlC(self, f):
-        def wrap(platform, *args, **kwargs):
-            try:
-                return f(platform, *args, **kwargs)
-            except:
-                info("Exception occured, killing background procs")
-                for p in copy.copy(self.bg_procs):
-                    self.kill_background_proc(p)
-                raise
-        return wrap
 
     def foreground_proc(self, cmd, expected_returncode=0):
         info("Starting foreground proc: \"{}\"".format(cmd))

--- a/pyenergy/src/platformrun/platformrun.py
+++ b/pyenergy/src/platformrun/platformrun.py
@@ -87,486 +87,469 @@ class LogWriter(object):
         pass
 
 
-def gdb_launch(gdbname, port, fname, run_timeout=30, post_commands=[],
-               pre_commands=[]):
-    info("Starting+connecting to gdb and loading file")
+class PlatformRun:
+    def gdb_launch(self, gdbname, port, fname, run_timeout=30,
+                   post_commands=[], pre_commands=[]):
+        info("Starting+connecting to gdb and loading file")
 
-    gdblogger = logger.getChild(os.path.split(gdbname)[-1])
-    gdb = pexpect.spawn(gdbname, logfile=LogWriter(gdblogger, logging.DEBUG))
+        gdblogger = logger.getChild(os.path.split(gdbname)[-1])
+        gdb = pexpect.spawn(gdbname, logfile=LogWriter(gdblogger,
+                                                       logging.DEBUG))
 
-    gdb.expect(r".*\(gdb\) ")
+        gdb.expect(r".*\(gdb\) ")
 
-    gdb.sendline("set confirm off")
-    gdb.expect(r".*\(gdb\) ")
+        gdb.sendline("set confirm off")
+        gdb.expect(r".*\(gdb\) ")
 
-    gdb.sendline("target remote :{}".format(port))
-    gdb.expect(r'Remote debugging using.*\n')
-    gdb.expect(r'.*\n')
-    gdb.expect(r".*\(gdb\) ")
+        gdb.sendline("target remote :{}".format(port))
+        gdb.expect(r'Remote debugging using.*\n')
+        gdb.expect(r'.*\n')
+        gdb.expect(r".*\(gdb\) ")
 
-    for cmd in pre_commands:
-        gdb.sendline(cmd)
-        gdb.expect(r'.*\(gdb\) ')
+        for cmd in pre_commands:
+            gdb.sendline(cmd)
+            gdb.expect(r'.*\(gdb\) ')
 
-    info("load file {}".format(fname))
-    gdb.sendline("file {}".format(fname))
-    gdb.expect(r'Reading symbols.*\n')
-    gdb.expect(r".*\(gdb\) ")
+        info("load file {}".format(fname))
+        gdb.sendline("file {}".format(fname))
+        gdb.expect(r'Reading symbols.*\n')
+        gdb.expect(r".*\(gdb\) ")
 
-    gdb.sendline("load")
-    while True:
-        a = gdb.expect([r'Loading section.*\n', r'Start address.*\n',
-                        r"Error finishing flash operation.*\n"])
-        if a == 1:
-            break
-        if a == 2:
-            gdb.expect(r".*\(gdb\) ")
-            gdb.sendline("load")
+        gdb.sendline("load")
+        while True:
+            a = gdb.expect([r'Loading section.*\n', r'Start address.*\n',
+                            r"Error finishing flash operation.*\n"])
+            if a == 1:
+                break
+            if a == 2:
+                gdb.expect(r".*\(gdb\) ")
+                gdb.sendline("load")
 
-    gdb.expect(r'Transfer rate.*\n')
-    gdb.expect(r'\(gdb\) ')
+        gdb.expect(r'Transfer rate.*\n')
+        gdb.expect(r'\(gdb\) ')
 
-    gdb.sendline("delete breakpoints")
-    gdb.expect(r".*\(gdb\) ")
+        gdb.sendline("delete breakpoints")
+        gdb.expect(r".*\(gdb\) ")
 
-    gdb.sendline("break exit")
-    gdb.expect(r'.*Breakpoint .*\n')
-    gdb.expect(r".*\(gdb\) ")
+        gdb.sendline("break exit")
+        gdb.expect(r'.*Breakpoint .*\n')
+        gdb.expect(r".*\(gdb\) ")
 
-    gdb.sendline("break _exit")
-    gdb.expect(r'.*Breakpoint .*\n')
-    gdb.expect(r".*\(gdb\) ")
+        gdb.sendline("break _exit")
+        gdb.expect(r'.*Breakpoint .*\n')
+        gdb.expect(r".*\(gdb\) ")
 
-    info("Sending continue to gdb")
-    gdb.sendline("continue")
-    gdb.expect(r'Continuing.*\n')
-    gdb.expect(r'.*Breakpoint.*exit.*\n', timeout=run_timeout)
+        info("Sending continue to gdb")
+        gdb.sendline("continue")
+        gdb.expect(r'Continuing.*\n')
+        gdb.expect(r'.*Breakpoint.*exit.*\n', timeout=run_timeout)
 
-    info("Breakpoint hit")
+        info("Breakpoint hit")
 
-    for cmd in post_commands:
-        gdb.sendline(cmd)
-        gdb.expect(r'.*\(gdb\) ')
+        for cmd in post_commands:
+            gdb.sendline(cmd)
+            gdb.expect(r'.*\(gdb\) ')
 
-    info("Quitting GDB")
-    gdb.sendline("quit")
+        info("Quitting GDB")
+        gdb.sendline("quit")
 
-bg_procs = []
-bg_proc_map = {}
+    def __init__(self):
+        self.bg_procs = []
+        self.bg_proc_map = {}
 
+    def background_proc(self, cmd, env=None):
 
-def background_proc(cmd, env=None):
+        def run_proc(ev):
+            info("Starting background proc: \"{}\"".format(cmd))
 
-    def run_proc(ev):
-        info("Starting background proc: \"{}\"".format(cmd))
+            proclogger = logger.getChild(os.path.split(cmd.split(' ')[0])[-1])
+            proc = pexpect.spawn(cmd, logfile=LogWriter(proclogger,
+                                                        logging.DEBUG),
+                                 env=env)
 
-        proclogger = logger.getChild(os.path.split(cmd.split(' ')[0])[-1])
-        proc = pexpect.spawn(cmd, logfile=LogWriter(proclogger, logging.DEBUG),
-                             env=env)
+            while not ev.isSet():
+                proc.expect([r'.*\n', pexpect.EOF, pexpect.TIMEOUT], timeout=1)
+                sleep(0.1)
 
-        while not ev.isSet():
-            proc.expect([r'.*\n', pexpect.EOF, pexpect.TIMEOUT], timeout=1)
-            sleep(0.1)
+            info("Killing background proc: \"{}\"".format(cmd))
+            proc.kill(15)
+            sleep(0.2)
+            if proc.isalive():
+                warning("Killing (sig 9) background proc: \"{}\"".format(cmd))
+                proc.kill(9)
 
-        info("Killing background proc: \"{}\"".format(cmd))
-        proc.kill(15)
-        sleep(0.2)
-        if proc.isalive():
-            warning("Killing (sig 9) background proc: \"{}\"".format(cmd))
-            proc.kill(9)
+        ev = threading.Event()
+        t = threading.Thread(target=run_proc, args=(ev,))
+        t.start()
 
-    ev = threading.Event()
-    t = threading.Thread(target=run_proc, args=(ev,))
-    t.start()
+        self.bg_procs.append(ev)
+        self.bg_proc_map[ev] = t
 
-    bg_procs.append(ev)
-    bg_proc_map[ev] = t
+        return ev
 
-    return ev
+    def kill_background_proc(self, p):
+        p.set()
+        info("Waiting for background process to exit " + str(p))
+        self.bg_proc_map[p].join()
+        sleep(0.1)
+        self.bg_procs.remove(p)
 
-
-def kill_background_proc(p):
-    p.set()
-    info("Waiting for background process to exit " + str(p))
-    bg_proc_map[p].join()
-    sleep(0.1)
-    bg_procs.remove(p)
-
-
-def killBgOnCtrlC(f):
-    def wrap(platform, *args, **kwargs):
-        try:
-            return f(platform, *args, **kwargs)
-        except:
-            info("Exception occured, killing background procs")
-            for p in copy.copy(bg_procs):
-                kill_background_proc(p)
-            raise
-    return wrap
-
-
-def foreground_proc(cmd, expected_returncode=0):
-    info("Starting foreground proc: \"{}\"".format(cmd))
-
-    proclogger = logger.getChild(cmd.split(' ')[0])
-
-    proc = pexpect.spawn(cmd, logfile=LogWriter(proclogger, logging.DEBUG))
-
-    proc.expect(pexpect.EOF)
-
-    # Even though we have received an EOF, the process may not be
-    # fully dead. Therefore, we wait. An exception is raised if the
-    # process is already dead
-    try:
-        proc.wait()
-    except pexpect.ExceptionPexpect:
-        pass
-
-    if (expected_returncode is not None and
-            proc.exitstatus != expected_returncode):
-        raise CommandError(
-            "Command \"{}\" returned {}".format(cmd, proc.exitstatus))
-    info("Foreground proc complete")
-
-
-def setupMeasurement(platform, doMeasure=True):
-    if not doMeasure:
-        return None
-
-    # First check that all tools for platform are available
-    if platform not in tool_config['enabled']:
-        raise RuntimeError(
-            "Platform {0} does not have all the tools configured. "
-            "Please rerun configure with --enable-{0}".format(platform))
-
-    em = pyenergy.EnergyMonitor(measurement_config[platform]['energy-monitor'])
-
-    mp_cfg = measurement_config[platform]['measurement-point']
-    if type(mp_cfg) is int:
-        mpoints = [mp_cfg]
-        resistors = [measurement_config[platform]['resistor']]
-    elif type(mp_cfg) is list:
-        mpoints = mp_cfg
-        resistors = measurement_config[platform]['resistor']
-    # mp = int(measurement_config[platform]['measurement-point'])
-
-    em.connect()
-    for mp, resistor in zip(mpoints, resistors):
-        em.enableMeasurementPoint(mp)
-        em.clearNumberOfRuns(mp)
-        em.measurement_params[mp]['resistor'] = float(resistor)
-        em.setTrigger(measurement_config[platform]['trigger-pin'], mp)
-
-    return em
-
-
-def finishMeasurement(platform, em, doMeasure=True, timeout=30):
-    if not doMeasure:
-        return None
-
-    mp_cfg = measurement_config[platform]['measurement-point']
-    if type(mp_cfg) is int:
-        mpoints = [mp_cfg]
-        resistors = [measurement_config[platform]['resistor']]
-    elif type(mp_cfg) is list:
-        mpoints = mp_cfg
-        resistors = measurement_config[platform]['resistor']
-
-    info("Waiting for measurement to complete")
-    t = 0
-    for mp in mpoints:
-        while not em.measurementCompleted(mp):
-            sleep(0.1)
-            t += 1
-            if t > timeout * 10:
-                raise CommandError("Measurement timeout")
-    info("Measurement complete")
-
-    if type(mp_cfg) is list:
-        measurements = map(em.getMeasurement, mpoints)
-        m = pyenergy.MeasurementSet(measurements)
-    else:
-        m = em.getMeasurement(mp)
-
-    em.disconnect()
-    return m
-
-
-# Display units nicer
-def prettyPrint(v):
-    units = [' ', 'm', 'u', 'n', 'p']
-
-    for unit in units:
-        if v > 1.0:
-            return "{: >8.3f} {}".format(v, unit)
-        v *= 1000.
-    return "{}".format(v)
-
-#######################################################################
-
-
-def loadConfiguration(fname="~/.measurementrc"):
-    global measurement_config
-
-    fname = os.path.expanduser(fname)
-    measurement_config = json.load(open(fname))
-
-
-def loadToolConfiguration(fname="~/.platformrunrc"):
-    global tool_config
-
-    fname = os.path.expanduser(fname)
-    tool_config = json.load(open(fname))
-
-##
-
-
-def findUSBLocation(devid):
-    info("Discovering USB bus address of {}".format(devid))
-
-    for bus in usb.busses():
-        for dev in bus.devices:
+    def killBgOnCtrlC(self, f):
+        def wrap(platform, *args, **kwargs):
             try:
-                print
-                if devid.lower() == "{:04x}:{:04x}".format(dev.idVendor,
-                                                           dev.idProduct):
-                    addr = "{:03}:{:03}".format(dev.dev.bus, dev.dev.address)
-                    info("Found {}".format(addr))
-                    return addr
-            except usb.core.USBError:
-                pass
-    warning("Could not find device location for {}. "
-            "The wrong board may be selected".format(addr))
-    return ""
+                return f(platform, *args, **kwargs)
+            except:
+                info("Exception occured, killing background procs")
+                for p in copy.copy(self.bg_procs):
+                    self.kill_background_proc(p)
+                raise
+        return wrap
 
+    def foreground_proc(self, cmd, expected_returncode=0):
+        info("Starting foreground proc: \"{}\"".format(cmd))
 
-#######################################################################
+        proclogger = logger.getChild(cmd.split(' ')[0])
 
-@killBgOnCtrlC
-def stm32f0discovery(fname, doMeasure=True):
-    em = setupMeasurement("stm32f0discovery", doMeasure)
+        proc = pexpect.spawn(cmd, logfile=LogWriter(proclogger, logging.DEBUG))
 
-    stproc = background_proc(tool_config['tools']['stutil'] +
-                             " -s 2 -p 2001 -c 0x0bb11477 -v0")
-    gdb_launch(tool_config['tools']['arm_gdb'], 2001, fname)
-    kill_background_proc(stproc)
+        proc.expect(pexpect.EOF)
 
-    return finishMeasurement("stm32f0discovery", em, doMeasure)
+        # Even though we have received an EOF, the process may not be
+        # fully dead. Therefore, we wait. An exception is raised if the
+        # process is already dead
+        try:
+            proc.wait()
+        except pexpect.ExceptionPexpect:
+            pass
 
+        if (expected_returncode is not None and
+                proc.exitstatus != expected_returncode):
+            raise CommandError(
+                "Command \"{}\" returned {}".format(cmd, proc.exitstatus))
+        info("Foreground proc complete")
 
-@killBgOnCtrlC
-def stm32vldiscovery(fname, doMeasure=True):
-    em = setupMeasurement("stm32vldiscovery", doMeasure)
+    def setupMeasurement(platform, doMeasure=True):
+        if not doMeasure:
+            return None
 
-    stproc = background_proc(tool_config['tools']['stutil'] +
-                             " -s 1 -p 2002 -c 0x1ba01477 -v0")
-    gdb_launch(tool_config['tools']['arm_gdb'], 2002, fname)
-    kill_background_proc(stproc)
+        # First check that all tools for platform are available
+        if platform not in tool_config['enabled']:
+            raise RuntimeError(
+                "Platform {0} does not have all the tools configured. "
+                "Please rerun configure with --enable-{0}".format(platform))
 
-    return finishMeasurement("stm32vldiscovery", em, doMeasure)
+        em = pyenergy.EnergyMonitor(
+            measurement_config[platform]['energy-monitor'])
 
+        mp_cfg = measurement_config[platform]['measurement-point']
+        if type(mp_cfg) is int:
+            mpoints = [mp_cfg]
+            resistors = [measurement_config[platform]['resistor']]
+        elif type(mp_cfg) is list:
+            mpoints = mp_cfg
+            resistors = measurement_config[platform]['resistor']
+        # mp = int(measurement_config[platform]['measurement-point'])
 
-@killBgOnCtrlC
-def stm32f4discovery(fname, doMeasure=True):
-    em = setupMeasurement("stm32f4discovery", doMeasure)
+        em.connect()
+        for mp, resistor in zip(mpoints, resistors):
+            em.enableMeasurementPoint(mp)
+            em.clearNumberOfRuns(mp)
+            em.measurement_params[mp]['resistor'] = float(resistor)
+            em.setTrigger(measurement_config[platform]['trigger-pin'], mp)
 
-    stproc = background_proc(tool_config['tools']['stutil'] +
-                             " -s 2 -p 2003 -c 0x2ba01477 -v0")
-    gdb_launch(tool_config['tools']['arm_gdb'], 2003, fname)
-    kill_background_proc(stproc)
+        return em
 
-    return finishMeasurement("stm32f4discovery", em, doMeasure)
+    def finishMeasurement(platform, em, doMeasure=True, timeout=30):
+        if not doMeasure:
+            return None
 
+        mp_cfg = measurement_config[platform]['measurement-point']
+        if type(mp_cfg) is int:
+            mpoints = [mp_cfg]
+            # resistors = [measurement_config[platform]['resistor']]
+        elif type(mp_cfg) is list:
+            mpoints = mp_cfg
+            # resistors = measurement_config[platform]['resistor']
 
-@killBgOnCtrlC
-def stm32l0discovery(fname, doMeasure=True):
-    em = setupMeasurement("stm32l0discovery", doMeasure)
+        info("Waiting for measurement to complete")
+        t = 0
+        for mp in mpoints:
+            while not em.measurementCompleted(mp):
+                sleep(0.1)
+                t += 1
+                if t > timeout * 10:
+                    raise CommandError("Measurement timeout")
+        info("Measurement complete")
 
-    stproc = background_proc(tool_config['tools']['openocd'] +
-                             ' -f board/stm32l0discovery.cfg '
-                             '--command "gdb_port 2004"')
-    gdb_launch(tool_config['tools']['arm_gdb'], 2004, fname,
-               post_commands=["monitor shutdown"],
-               pre_commands=["monitor reset init"])
-    kill_background_proc(stproc)
+        if type(mp_cfg) is list:
+            measurements = map(em.getMeasurement, mpoints)
+            m = pyenergy.MeasurementSet(measurements)
+        else:
+            m = em.getMeasurement(mp)
 
-    return finishMeasurement("stm32l0discovery", em, doMeasure)
+        em.disconnect()
+        return m
 
+    # Display units nicer
+    def prettyPrint(v):
+        units = [' ', 'm', 'u', 'n', 'p']
 
-@killBgOnCtrlC
-def beaglebone(fname, doMeasure=True):
-    em = setupMeasurement("beaglebone", doMeasure)
+        for unit in units:
+            if v > 1.0:
+                return "{: >8.3f} {}".format(v, unit)
+            v *= 1000.
+        return "{}".format(v)
 
-    openocdproc = background_proc(tool_config['tools']['openocd'] +
-                                  " -f board/ti_beaglebone.cfg")
-    gdb_launch(tool_config['tools']['arm_gdb'], 3333, fname,
-               post_commands=["monitor shutdown"],
-               pre_commands=["monitor reset halt"])
-    kill_background_proc(openocdproc)
+    #######################################################################
 
-    return finishMeasurement("beaglebone", em, doMeasure)
+    def loadConfiguration(fname="~/.measurementrc"):
+        global measurement_config
 
+        fname = os.path.expanduser(fname)
+        measurement_config = json.load(open(fname))
 
-def atmega328p(fname, doMeasure=True):
-    # Create temporary file and convert to hex file
-    tf = tempfile.NamedTemporaryFile(delete=False)
-    tf.close()
-    foreground_proc(
-        "{} -O ihex {} {}".format(tool_config['tools']['avr_objcopy'], fname,
-                                  tf.name))
+    def loadToolConfiguration(fname="~/.platformrunrc"):
+        global tool_config
 
-    # Flash the hex file to the AVR chip
-    if logger.getEffectiveLevel() == logging.DEBUG:
-        silence = ""
-    elif logger.getEffectiveLevel() == logging.INFO:
-        silence = "-q"
-    else:
-        silence = "-q -q"
+        fname = os.path.expanduser(fname)
+        tool_config = json.load(open(fname))
 
-    ser_id = measurement_config['atmega328p']['serial-dev-id']
-    ser_path = "/dev/serial/by-id/{}".format(ser_id)
+    ##
 
-    if not os.path.exists(ser_path):
-        raise RuntimeError("Cannot find the serial device: "+ser_path)
+    def findUSBLocation(devid):
+        info("Discovering USB bus address of {}".format(devid))
 
-    cmdline = "readlink -m " + ser_path
-    location = pexpect.run(cmdline).strip()
-    info("AVR programmer @ {}".format(location))
+        for bus in usb.busses():
+            for dev in bus.devices:
+                try:
+                    print
+                    if devid.lower() == "{:04x}:{:04x}".format(dev.idVendor,
+                                                               dev.idProduct):
+                        addr = "{:03}:{:03}".format(dev.dev.bus,
+                                                    dev.dev.address)
+                        info("Found {}".format(addr))
+                        return addr
+                except usb.core.USBError:
+                    pass
+        warning("Could not find device location for {}. "
+                "The wrong board may be selected".format(addr))
+        return ""
 
-    # info("Perform erase of the chip")
-    # cmdline = "{} -F -c arduino -p atmega328p -e -P {} -b 115200".format(
-    # tool_config['tools']['avrdude'], location)
-    # foreground_proc(cmdline)
+    #######################################################################
+    @killBgOnCtrlC
+    def stm32f0discovery(self, fname, doMeasure=True):
+        em = self.setupMeasurement("stm32f0discovery", doMeasure)
 
-    em = setupMeasurement("atmega328p", doMeasure)
+        stproc = self.background_proc(tool_config['tools']['stutil'] +
+                                      " -s 2 -p 2001 -c 0x0bb11477 -v0")
+        self.gdb_launch(tool_config['tools']['arm_gdb'], 2001, fname)
+        self.kill_background_proc(stproc)
 
-    cmdline = ("{} -F -V -c arduino -p atmega328p -P {} -b 115200"
-               "-U flash:w:{}").format(
-                   tool_config['tools']['avrdude'], location, tf.name)
-    foreground_proc(cmdline)
+        return self.finishMeasurement("stm32f0discovery", em, doMeasure)
 
-    try:
+    @killBgOnCtrlC
+    def stm32vldiscovery(self, fname, doMeasure=True):
+        em = self.setupMeasurement("stm32vldiscovery", doMeasure)
+
+        stproc = self.background_proc(tool_config['tools']['stutil'] +
+                                      " -s 1 -p 2002 -c 0x1ba01477 -v0")
+        self.gdb_launch(tool_config['tools']['arm_gdb'], 2002, fname)
+        self.ill_background_proc(stproc)
+
+        return self.finishMeasurement("stm32vldiscovery", em, doMeasure)
+
+    @killBgOnCtrlC
+    def stm32f4discovery(self, fname, doMeasure=True):
+        em = self.setupMeasurement("stm32f4discovery", doMeasure)
+
+        stproc = self.background_proc(tool_config['tools']['stutil'] +
+                                      " -s 2 -p 2003 -c 0x2ba01477 -v0")
+        self.gdb_launch(tool_config['tools']['arm_gdb'], 2003, fname)
+        self.kill_background_proc(stproc)
+
+        return self.finishMeasurement("stm32f4discovery", em, doMeasure)
+
+    @killBgOnCtrlC
+    def stm32l0discovery(self, fname, doMeasure=True):
+        em = self.setupMeasurement("stm32l0discovery", doMeasure)
+
+        stproc = self.background_proc(tool_config['tools']['openocd'] +
+                                      ' -f board/stm32l0discovery.cfg '
+                                      '--command "gdb_port 2004"')
+        self.gdb_launch(tool_config['tools']['arm_gdb'], 2004, fname,
+                        post_commands=["monitor shutdown"],
+                        pre_commands=["monitor reset init"])
+        self.kill_background_proc(stproc)
+
+        return self.finishMeasurement("stm32l0discovery", em, doMeasure)
+
+    @killBgOnCtrlC
+    def beaglebone(self, fname, doMeasure=True):
+        em = self.setupMeasurement("beaglebone", doMeasure)
+
+        openocdproc = self.background_proc(tool_config['tools']['openocd'] +
+                                           " -f board/ti_beaglebone.cfg")
+        self.gdb_launch(tool_config['tools']['arm_gdb'], 3333, fname,
+                        post_commands=["monitor shutdown"],
+                        pre_commands=["monitor reset halt"])
+        self.kill_background_proc(openocdproc)
+
+        return self.finishMeasurement("beaglebone", em, doMeasure)
+
+    def atmega328p(self, fname, doMeasure=True):
+        # Create temporary file and convert to hex file
+        tf = tempfile.NamedTemporaryFile(delete=False)
+        tf.close()
+        self.foreground_proc(
+            "{} -O ihex {} {}".format(tool_config['tools']['avr_objcopy'],
+                                      fname, tf.name))
+
+        # Flash the hex file to the AVR chip
+        """if logger.getEffectiveLevel() == logging.DEBUG:
+            silence = ""
+        elif logger.getEffectiveLevel() == logging.INFO:
+            silence = "-q"
+        else:
+            silence = "-q -q" """
+
+        ser_id = measurement_config['atmega328p']['serial-dev-id']
+        ser_path = "/dev/serial/by-id/{}".format(ser_id)
+
+        if not os.path.exists(ser_path):
+            raise RuntimeError("Cannot find the serial device: "+ser_path)
+
+        cmdline = "readlink -m " + ser_path
+        location = pexpect.run(cmdline).strip()
+        info("AVR programmer @ {}".format(location))
+
+        # info("Perform erase of the chip")
+        # cmdline = "{} -F -c arduino -p atmega328p -e -P {} -b 115200".format(
+        # tool_config['tools']['avrdude'], location)
+        # self.foreground_proc(cmdline)
+
+        em = self.setupMeasurement("atmega328p", doMeasure)
+
+        cmdline = ("{} -F -V -c arduino -p atmega328p -P {} -b 115200"
+                   "-U flash:w:{}").format(
+                       tool_config['tools']['avrdude'], location, tf.name)
+        self.foreground_proc(cmdline)
+
+        try:
+            os.unlink(tf.name)
+        except OSError:
+            pass
+        return self.finishMeasurement("atmega328p", em, doMeasure)
+
+    def xmegaa3buxplained(self, fname, doMeasure=True):
+        em = self.setupMeasurement("xmegaa3buxplained", doMeasure)
+
+        # Create temporary file and convert to hex file
+        tf = tempfile.NamedTemporaryFile(delete=False)
+        tf.close()
+        self.foreground_proc("{} -O ihex {} {}".format(
+            tool_config['tools']['avr_objcopy'], fname, tf.name))
+
+        # Flash the hex file to the AVR chip
+        """if logger.getEffectiveLevel() == logging.DEBUG:
+            silence = ""
+        elif logger.getEffectiveLevel() == logging.INFO:
+            silence = "-q"
+        else:
+            silence = "-q -q" """
+
+        cmdline = "{} -F -V -c jtag3 -p x256a3bu -e -U flash:w:{}".format(
+            tool_config['tools']['avrdude'], tf.name)
+        self.foreground_proc(cmdline)
+
+        try:
+            os.unlink(tf.name)
+        except OSError:
+            pass
+        return self.finishMeasurement("xmegaa3buxplained", em, doMeasure)
+
+    def mspexp430f5529(self, fname, doMeasure=True):
+        em = self.setupMeasurement("msp-exp430f5529", doMeasure)
+
+        self.foreground_proc("{} tilib -q \"prog {}\" &".format(
+            tool_config['tools']['mspdebug'], fname))
+
+        return self.finishMeasurement("msp-exp430f5529", em, doMeasure)
+
+    def mspexp430fr5739(self, fname, doMeasure=True):
+        em = self.setupMeasurement("msp-exp430fr5739", doMeasure)
+
+        self.foreground_proc("{} rf2500 \"prog {}\" &".format(
+            tool_config['tools']['mspdebug'], fname), expected_returncode=None)
+
+        return self.finishMeasurement("msp-exp430fr5739", em, doMeasure)
+
+    def pic32mx250f128b(self, fname, doMeasure=True):
+        # Create temporary file and convert to hex fil, doMeasuree
+        tf = tempfile.NamedTemporaryFile(delete=False)
+        tf.close()
+        self.foreground_proc("{} -O ihex {} {}".format(
+            tool_config['tools']['pic32_objcopy'], fname, tf.name))
+
+        # Program the PIC and leave power on to run test
+        em = self.setupMeasurement("pic32mx250f128b")
+        self.foreground_proc(
+            "{} -p {}".format(tool_config['tools']['pic32prog'], tf.name))
+
         os.unlink(tf.name)
-    except OSError:
-        pass
-    return finishMeasurement("atmega328p", em, doMeasure)
+        return self.finishMeasurement("pic32mx250f128b", em, doMeasure)
 
+    @killBgOnCtrlC
+    def sam4lxplained(self, fname, doMeasure=True):
+        em = self.setupMeasurement("sam4lxplained", doMeasure)
 
-def xmegaa3buxplained(fname, doMeasure=True):
-    em = setupMeasurement("xmegaa3buxplained", doMeasure)
+        openocdproc = self.background_proc(
+            tool_config['tools']['openocd'] +
+            " -f board/atmel_sam4l8_xplained_pro.cfg")
+        self.gdb_launch(tool_config['tools']['arm_gdb'], 3333, fname,
+                        post_commands=["monitor shutdown"])
+        self.kill_background_proc(openocdproc)
 
-    # Create temporary file and convert to hex file
-    tf = tempfile.NamedTemporaryFile(delete=False)
-    tf.close()
-    foreground_proc("{} -O ihex {} {}".format(
-        tool_config['tools']['avr_objcopy'], fname, tf.name))
+        return self.finishMeasurement("sam4lxplained", em, doMeasure)
 
-    # Flash the hex file to the AVR chip
-    if logger.getEffectiveLevel() == logging.DEBUG:
-        silence = ""
-    elif logger.getEffectiveLevel() == logging.INFO:
-        silence = "-q"
-    else:
-        silence = "-q -q"
+    def run(self, platformname, execname, measurement=True):
 
-    cmdline = "{} -F -V -c jtag3 -p x256a3bu -e -U flash:w:{}".format(
-        tool_config['tools']['avrdude'], tf.name)
-    foreground_proc(cmdline)
+        if not os.path.isfile(execname):
+            raise IOError("File \"{}\" does not exist".format(execname))
 
-    try:
-        os.unlink(tf.name)
-    except OSError:
-        pass
-    return finishMeasurement("xmegaa3buxplained", em, doMeasure)
+        if platformname == "stm32f0discovery":
+            m = self.stm32f0discovery(execname, measurement)
+        elif platformname == "stm32vldiscovery":
+            m = self.stm32vldiscovery(execname, measurement)
+        elif platformname == "stm32f4discovery":
+            m = self.stm32f4discovery(execname, measurement)
+        elif platformname == "stm32l0discovery":
+            m = self.stm32l0discovery(execname, measurement)
+        elif platformname == "beaglebone":
+            m = self.beaglebone(execname, measurement)
+        elif platformname == "atmega328p":
+            m = self.atmega328p(execname, measurement)
+        elif platformname == "xmegaa3buxplained":
+            m = self.xmegaa3buxplained(execname, measurement)
+        elif platformname == "pic32mx250f128b":
+            m = self.pic32mx250f128b(execname, measurement)
+        elif platformname == "msp-exp430f5529":
+            m = self.mspexp430f5529(execname, measurement)
+        elif platformname == "msp-exp430fr5739":
+            m = self.mspexp430fr5739(execname, measurement)
+        elif platformname == "sam4lxplained":
+            m = self.sam4lxplained(execname, measurement)
+        else:
+            raise RuntimeError("Unknown platform " + platformname)
+        return m
 
+    def run_multiple(self, platformname, execname, repeats, measurement=True):
+        measurements = []
 
-def mspexp430f5529(fname, doMeasure=True):
-    em = setupMeasurement("msp-exp430f5529", doMeasure)
+        for i in range(repeats):
+            m = self.run(platformname, execname, measurement)
+            measurements.append(m)
 
-    foreground_proc("{} tilib -q \"prog {}\" &".format(
-        tool_config['tools']['mspdebug'], fname))
-
-    return finishMeasurement("msp-exp430f5529", em, doMeasure)
-
-
-def mspexp430fr5739(fname, doMeasure=True):
-    em = setupMeasurement("msp-exp430fr5739", doMeasure)
-
-    foreground_proc("{} rf2500 \"prog {}\" &".format(
-        tool_config['tools']['mspdebug'], fname), expected_returncode=None)
-
-    return finishMeasurement("msp-exp430fr5739", em, doMeasure)
-
-
-def pic32mx250f128b(fname, doMeasure=True):
-    # Create temporary file and convert to hex fil, doMeasuree
-    tf = tempfile.NamedTemporaryFile(delete=False)
-    tf.close()
-    foreground_proc("{} -O ihex {} {}".format(
-        tool_config['tools']['pic32_objcopy'], fname, tf.name))
-
-    # Program the PIC and leave power on to run test
-    em = setupMeasurement("pic32mx250f128b")
-    foreground_proc("{} -p {}".format(tool_config['tools']['pic32prog'],
-                                      tf.name))
-
-    os.unlink(tf.name)
-    return finishMeasurement("pic32mx250f128b", em, doMeasure)
-
-
-@killBgOnCtrlC
-def sam4lxplained(fname, doMeasure=True):
-    em = setupMeasurement("sam4lxplained", doMeasure)
-
-    openocdproc = background_proc(tool_config['tools']['openocd'] +
-                                  " -f board/atmel_sam4l8_xplained_pro.cfg")
-    gdb_launch(tool_config['tools']['arm_gdb'], 3333, fname,
-               post_commands=["monitor shutdown"])
-    kill_background_proc(openocdproc)
-
-    return finishMeasurement("sam4lxplained", em, doMeasure)
-
-
-def run(platformname, execname, measurement=True):
-
-    if not os.path.isfile(execname):
-        raise IOError("File \"{}\" does not exist".format(execname))
-
-    if platformname == "stm32f0discovery":
-        m = stm32f0discovery(execname, measurement)
-    elif platformname == "stm32vldiscovery":
-        m = stm32vldiscovery(execname, measurement)
-    elif platformname == "stm32f4discovery":
-        m = stm32f4discovery(execname, measurement)
-    elif platformname == "stm32l0discovery":
-        m = stm32l0discovery(execname, measurement)
-    elif platformname == "beaglebone":
-        m = beaglebone(execname, measurement)
-    elif platformname == "atmega328p":
-        m = atmega328p(execname, measurement)
-    elif platformname == "xmegaa3buxplained":
-        m = xmegaa3buxplained(execname, measurement)
-    elif platformname == "pic32mx250f128b":
-        m = pic32mx250f128b(execname, measurement)
-    elif platformname == "msp-exp430f5529":
-        m = mspexp430f5529(execname, measurement)
-    elif platformname == "msp-exp430fr5739":
-        m = mspexp430fr5739(execname, measurement)
-    elif platformname == "sam4lxplained":
-        m = sam4lxplained(execname, measurement)
-    else:
-        raise RuntimeError("Unknown platform " + platformname)
-    return m
-
-
-def run_multiple(platformname, execname, repeats, measurement=True):
-    measurements = []
-
-    for i in range(repeats):
-        m = run(platformname, execname, measurement)
-        measurements.append(m)
-
-    return sum(measurements) / len(measurements)
+        return sum(measurements) / len(measurements)
 
 
 def main():
@@ -579,16 +562,17 @@ def main():
     elif arguments['--verbose'] == 2:
         logging.getLogger('').setLevel(logging.DEBUG)
 
-    loadConfiguration(arguments['--config'])
-    loadToolConfiguration(arguments['--tools'])
+    PR = PlatformRun()
+
+    PR.loadConfiguration(arguments['--config'])
+    PR.loadToolConfiguration(arguments['--tools'])
 
     try:
         # Execute multiple repeats, if requested
         ms = []
         for i in range(int(arguments['--repeat'])):
-            m = run(arguments['PLATFORM'],
-                    arguments['EXECUTABLE'],
-                    arguments['--no-measure'] is False)
+            m = PR.run(arguments['PLATFORM'], arguments['EXECUTABLE'],
+                       arguments['--no-measure'] is False)
             ms.append(m)
 
         m = sum(ms) / len(ms)
@@ -617,16 +601,19 @@ def main():
                 for name, key, unit in zip(names, keys, units):
                     print "{}:{}".format(name, " " * (15-len(name))),
                     for meas in m.measurements:
-                        print "{}{}".format(prettyPrint(meas.__dict__[key]),
+                        print "{}{}".format(PR.prettyPrint(meas.__dict__[key]),
                                             unit),
                     print
 
             else:
-                print "Energy:          {}J".format(prettyPrint(m.energy))
-                print "Time:            {}s".format(prettyPrint(m.time))
-                print "Power:           {}W".format(prettyPrint(m.avg_power))
-                print "Average current: {}A".format(prettyPrint(m.avg_current))
-                print "Average voltage: {}V".format(prettyPrint(m.avg_voltage))
+                print "Energy:          {}J".format(PR.prettyPrint(m.energy))
+                print "Time:            {}s".format(PR.prettyPrint(m.time))
+                print "Power:           {}W".format(
+                    PR.prettyPrint(m.avg_power))
+                print "Average current: {}A".format(
+                    PR.prettyPrint(m.avg_current))
+                print "Average voltage: {}V".format(
+                    PR.prettyPrint(m.avg_voltage))
 
 if __name__ == "__main__":
     main()

--- a/pyenergy/src/platformrun/platformrun.py
+++ b/pyenergy/src/platformrun/platformrun.py
@@ -338,14 +338,13 @@ class PlatformRun:
 
     #######################################################################
 
-    @killBgOnCtrlC
     def platform_xmosslicekita16(self, fname, doMeasure=True):
         name = "xmosslicekita16"
         em = self.setupMeasurement(name, doMeasure)
 
-        xrunproc = self.background_proc(tool_config['tools']['xrun'] +
-                                        " --xscope")
-        self.kill_background_proc(xrunproc)
+        self.foreground_proc(tool_config['tools']['xrun'] +
+                             " --xscope " + fname)
+        # self.kill_background_proc(xrunproc)
 
         return self.finishMeasurement(name, em, doMeasure)
 

--- a/pyenergy/src/platformrun/platformrun.py
+++ b/pyenergy/src/platformrun/platformrun.py
@@ -34,9 +34,9 @@ Options:
 """
 from docopt import docopt
 
-import subprocess, os, os.path
+import os
+import os.path
 import threading
-from collections import namedtuple
 import tempfile
 import json
 
@@ -45,7 +45,8 @@ from time import sleep
 import logging
 import usb
 
-import pexpect, sys, copy
+import pexpect
+import copy
 
 logger = logging.getLogger(__name__)
 warning = logger.warning
@@ -58,14 +59,17 @@ measurement_config = None
 
 #######################################################################
 
+
 class CommandError(RuntimeError):
     pass
+
 
 class LogWriter(object):
     def __init__(self, logger, level):
         self.logger = logger
         self.level = level
         self.current_msg = ""
+
     def write(self, msg):
         self.current_msg += msg
 
@@ -75,12 +79,16 @@ class LogWriter(object):
             self.current_msg = s[-1]
             for s in to_print:
                 self.logger.log(self.level, s)
+
     def flush(self):
         pass
+
     def close(self):
         pass
 
-def gdb_launch(gdbname, port, fname, run_timeout=30, post_commands=[], pre_commands=[]):
+
+def gdb_launch(gdbname, port, fname, run_timeout=30, post_commands=[],
+               pre_commands=[]):
     info("Starting+connecting to gdb and loading file")
 
     gdblogger = logger.getChild(os.path.split(gdbname)[-1])
@@ -107,7 +115,8 @@ def gdb_launch(gdbname, port, fname, run_timeout=30, post_commands=[], pre_comma
 
     gdb.sendline("load")
     while True:
-        a = gdb.expect([r'Loading section.*\n',r'Start address.*\n', r"Error finishing flash operation.*\n"])
+        a = gdb.expect([r'Loading section.*\n', r'Start address.*\n',
+                        r"Error finishing flash operation.*\n"])
         if a == 1:
             break
         if a == 2:
@@ -145,13 +154,15 @@ def gdb_launch(gdbname, port, fname, run_timeout=30, post_commands=[], pre_comma
 bg_procs = []
 bg_proc_map = {}
 
+
 def background_proc(cmd, env=None):
 
     def run_proc(ev):
         info("Starting background proc: \"{}\"".format(cmd))
 
         proclogger = logger.getChild(os.path.split(cmd.split(' ')[0])[-1])
-        proc = pexpect.spawn(cmd, logfile=LogWriter(proclogger, logging.DEBUG), env=env)
+        proc = pexpect.spawn(cmd, logfile=LogWriter(proclogger, logging.DEBUG),
+                             env=env)
 
         while not ev.isSet():
             proc.expect([r'.*\n', pexpect.EOF, pexpect.TIMEOUT], timeout=1)
@@ -173,12 +184,14 @@ def background_proc(cmd, env=None):
 
     return ev
 
+
 def kill_background_proc(p):
     p.set()
     info("Waiting for background process to exit " + str(p))
     bg_proc_map[p].join()
     sleep(0.1)
     bg_procs.remove(p)
+
 
 def killBgOnCtrlC(f):
     def wrap(platform, *args, **kwargs):
@@ -209,8 +222,10 @@ def foreground_proc(cmd, expected_returncode=0):
     except pexpect.ExceptionPexpect:
         pass
 
-    if expected_returncode is not None and proc.exitstatus != expected_returncode:
-        raise CommandError("Command \"{}\" returned {}".format(cmd, proc.exitstatus))
+    if (expected_returncode is not None and
+            proc.exitstatus != expected_returncode):
+        raise CommandError(
+            "Command \"{}\" returned {}".format(cmd, proc.exitstatus))
     info("Foreground proc complete")
 
 
@@ -220,7 +235,9 @@ def setupMeasurement(platform, doMeasure=True):
 
     # First check that all tools for platform are available
     if platform not in tool_config['enabled']:
-        raise RuntimeError("Platform {0} does not have all the tools configured. Please rerun configure with --enable-{0}".format(platform))
+        raise RuntimeError(
+            "Platform {0} does not have all the tools configured. "
+            "Please rerun configure with --enable-{0}".format(platform))
 
     em = pyenergy.EnergyMonitor(measurement_config[platform]['energy-monitor'])
 
@@ -241,6 +258,7 @@ def setupMeasurement(platform, doMeasure=True):
         em.setTrigger(measurement_config[platform]['trigger-pin'], mp)
 
     return em
+
 
 def finishMeasurement(platform, em, doMeasure=True, timeout=30):
     if not doMeasure:
@@ -264,7 +282,6 @@ def finishMeasurement(platform, em, doMeasure=True, timeout=30):
                 raise CommandError("Measurement timeout")
     info("Measurement complete")
 
-
     if type(mp_cfg) is list:
         measurements = map(em.getMeasurement, mpoints)
         m = pyenergy.MeasurementSet(measurements)
@@ -273,6 +290,7 @@ def finishMeasurement(platform, em, doMeasure=True, timeout=30):
 
     em.disconnect()
     return m
+
 
 # Display units nicer
 def prettyPrint(v):
@@ -286,11 +304,13 @@ def prettyPrint(v):
 
 #######################################################################
 
+
 def loadConfiguration(fname="~/.measurementrc"):
     global measurement_config
 
     fname = os.path.expanduser(fname)
     measurement_config = json.load(open(fname))
+
 
 def loadToolConfiguration(fname="~/.platformrunrc"):
     global tool_config
@@ -300,6 +320,7 @@ def loadToolConfiguration(fname="~/.platformrunrc"):
 
 ##
 
+
 def findUSBLocation(devid):
     info("Discovering USB bus address of {}".format(devid))
 
@@ -307,13 +328,15 @@ def findUSBLocation(devid):
         for dev in bus.devices:
             try:
                 print
-                if devid.lower() == "{:04x}:{:04x}".format(dev.idVendor, dev.idProduct):
+                if devid.lower() == "{:04x}:{:04x}".format(dev.idVendor,
+                                                           dev.idProduct):
                     addr = "{:03}:{:03}".format(dev.dev.bus, dev.dev.address)
                     info("Found {}".format(addr))
                     return addr
             except usb.core.USBError:
                 pass
-    warning("Could not find device location for {}. The wrong board may be selected".format(addr))
+    warning("Could not find device location for {}. "
+            "The wrong board may be selected".format(addr))
     return ""
 
 
@@ -323,7 +346,8 @@ def findUSBLocation(devid):
 def stm32f0discovery(fname, doMeasure=True):
     em = setupMeasurement("stm32f0discovery", doMeasure)
 
-    stproc = background_proc(tool_config['tools']['stutil'] + " -s 2 -p 2001 -c 0x0bb11477 -v0")
+    stproc = background_proc(tool_config['tools']['stutil'] +
+                             " -s 2 -p 2001 -c 0x0bb11477 -v0")
     gdb_launch(tool_config['tools']['arm_gdb'], 2001, fname)
     kill_background_proc(stproc)
 
@@ -334,38 +358,50 @@ def stm32f0discovery(fname, doMeasure=True):
 def stm32vldiscovery(fname, doMeasure=True):
     em = setupMeasurement("stm32vldiscovery", doMeasure)
 
-    stproc = background_proc(tool_config['tools']['stutil'] + " -s 1 -p 2002 -c 0x1ba01477 -v0")
+    stproc = background_proc(tool_config['tools']['stutil'] +
+                             " -s 1 -p 2002 -c 0x1ba01477 -v0")
     gdb_launch(tool_config['tools']['arm_gdb'], 2002, fname)
     kill_background_proc(stproc)
 
     return finishMeasurement("stm32vldiscovery", em, doMeasure)
 
+
 @killBgOnCtrlC
 def stm32f4discovery(fname, doMeasure=True):
     em = setupMeasurement("stm32f4discovery", doMeasure)
 
-    stproc = background_proc(tool_config['tools']['stutil'] + " -s 2 -p 2003 -c 0x2ba01477 -v0")
+    stproc = background_proc(tool_config['tools']['stutil'] +
+                             " -s 2 -p 2003 -c 0x2ba01477 -v0")
     gdb_launch(tool_config['tools']['arm_gdb'], 2003, fname)
     kill_background_proc(stproc)
 
     return finishMeasurement("stm32f4discovery", em, doMeasure)
 
+
 @killBgOnCtrlC
 def stm32l0discovery(fname, doMeasure=True):
     em = setupMeasurement("stm32l0discovery", doMeasure)
 
-    stproc = background_proc(tool_config['tools']['openocd'] + ' -f board/stm32l0discovery.cfg --command "gdb_port 2004"')
-    gdb_launch(tool_config['tools']['arm_gdb'], 2004, fname, post_commands=["monitor shutdown"], pre_commands=["monitor reset init"])
+    stproc = background_proc(tool_config['tools']['openocd'] +
+                             ' -f board/stm32l0discovery.cfg '
+                             '--command "gdb_port 2004"')
+    gdb_launch(tool_config['tools']['arm_gdb'], 2004, fname,
+               post_commands=["monitor shutdown"],
+               pre_commands=["monitor reset init"])
     kill_background_proc(stproc)
 
     return finishMeasurement("stm32l0discovery", em, doMeasure)
+
 
 @killBgOnCtrlC
 def beaglebone(fname, doMeasure=True):
     em = setupMeasurement("beaglebone", doMeasure)
 
-    openocdproc = background_proc(tool_config['tools']['openocd'] + " -f board/ti_beaglebone.cfg")
-    gdb_launch(tool_config['tools']['arm_gdb'], 3333, fname, post_commands=["monitor shutdown"], pre_commands=["monitor reset halt"])
+    openocdproc = background_proc(tool_config['tools']['openocd'] +
+                                  " -f board/ti_beaglebone.cfg")
+    gdb_launch(tool_config['tools']['arm_gdb'], 3333, fname,
+               post_commands=["monitor shutdown"],
+               pre_commands=["monitor reset halt"])
     kill_background_proc(openocdproc)
 
     return finishMeasurement("beaglebone", em, doMeasure)
@@ -375,7 +411,9 @@ def atmega328p(fname, doMeasure=True):
     # Create temporary file and convert to hex file
     tf = tempfile.NamedTemporaryFile(delete=False)
     tf.close()
-    foreground_proc("{} -O ihex {} {}".format(tool_config['tools']['avr_objcopy'], fname, tf.name))
+    foreground_proc(
+        "{} -O ihex {} {}".format(tool_config['tools']['avr_objcopy'], fname,
+                                  tf.name))
 
     # Flash the hex file to the AVR chip
     if logger.getEffectiveLevel() == logging.DEBUG:
@@ -396,12 +434,15 @@ def atmega328p(fname, doMeasure=True):
     info("AVR programmer @ {}".format(location))
 
     # info("Perform erase of the chip")
-    # cmdline = "{} -F -c arduino -p atmega328p -e -P {} -b 115200".format(tool_config['tools']['avrdude'], location)
+    # cmdline = "{} -F -c arduino -p atmega328p -e -P {} -b 115200".format(
+    # tool_config['tools']['avrdude'], location)
     # foreground_proc(cmdline)
 
     em = setupMeasurement("atmega328p", doMeasure)
 
-    cmdline = "{} -F -V -c arduino -p atmega328p -P {} -b 115200 -U flash:w:{}".format(tool_config['tools']['avrdude'], location, tf.name)
+    cmdline = ("{} -F -V -c arduino -p atmega328p -P {} -b 115200"
+               "-U flash:w:{}").format(
+                   tool_config['tools']['avrdude'], location, tf.name)
     foreground_proc(cmdline)
 
     try:
@@ -410,13 +451,15 @@ def atmega328p(fname, doMeasure=True):
         pass
     return finishMeasurement("atmega328p", em, doMeasure)
 
+
 def xmegaa3buxplained(fname, doMeasure=True):
     em = setupMeasurement("xmegaa3buxplained", doMeasure)
 
     # Create temporary file and convert to hex file
     tf = tempfile.NamedTemporaryFile(delete=False)
     tf.close()
-    foreground_proc("{} -O ihex {} {}".format(tool_config['tools']['avr_objcopy'], fname, tf.name))
+    foreground_proc("{} -O ihex {} {}".format(
+        tool_config['tools']['avr_objcopy'], fname, tf.name))
 
     # Flash the hex file to the AVR chip
     if logger.getEffectiveLevel() == logging.DEBUG:
@@ -426,7 +469,8 @@ def xmegaa3buxplained(fname, doMeasure=True):
     else:
         silence = "-q -q"
 
-    cmdline = "{} -F -V -c jtag3 -p x256a3bu -e -U flash:w:{}".format(tool_config['tools']['avrdude'], tf.name)
+    cmdline = "{} -F -V -c jtag3 -p x256a3bu -e -U flash:w:{}".format(
+        tool_config['tools']['avrdude'], tf.name)
     foreground_proc(cmdline)
 
     try:
@@ -439,7 +483,8 @@ def xmegaa3buxplained(fname, doMeasure=True):
 def mspexp430f5529(fname, doMeasure=True):
     em = setupMeasurement("msp-exp430f5529", doMeasure)
 
-    foreground_proc("{} tilib -q \"prog {}\" &".format(tool_config['tools']['mspdebug'], fname))
+    foreground_proc("{} tilib -q \"prog {}\" &".format(
+        tool_config['tools']['mspdebug'], fname))
 
     return finishMeasurement("msp-exp430f5529", em, doMeasure)
 
@@ -447,7 +492,8 @@ def mspexp430f5529(fname, doMeasure=True):
 def mspexp430fr5739(fname, doMeasure=True):
     em = setupMeasurement("msp-exp430fr5739", doMeasure)
 
-    foreground_proc("{} rf2500 \"prog {}\" &".format(tool_config['tools']['mspdebug'], fname), expected_returncode=None)
+    foreground_proc("{} rf2500 \"prog {}\" &".format(
+        tool_config['tools']['mspdebug'], fname), expected_returncode=None)
 
     return finishMeasurement("msp-exp430fr5739", em, doMeasure)
 
@@ -456,11 +502,13 @@ def pic32mx250f128b(fname, doMeasure=True):
     # Create temporary file and convert to hex fil, doMeasuree
     tf = tempfile.NamedTemporaryFile(delete=False)
     tf.close()
-    foreground_proc("{} -O ihex {} {}".format(tool_config['tools']['pic32_objcopy'], fname, tf.name))
+    foreground_proc("{} -O ihex {} {}".format(
+        tool_config['tools']['pic32_objcopy'], fname, tf.name))
 
     # Program the PIC and leave power on to run test
     em = setupMeasurement("pic32mx250f128b")
-    foreground_proc("{} -p {}".format(tool_config['tools']['pic32prog'], tf.name))
+    foreground_proc("{} -p {}".format(tool_config['tools']['pic32prog'],
+                                      tf.name))
 
     os.unlink(tf.name)
     return finishMeasurement("pic32mx250f128b", em, doMeasure)
@@ -470,8 +518,10 @@ def pic32mx250f128b(fname, doMeasure=True):
 def sam4lxplained(fname, doMeasure=True):
     em = setupMeasurement("sam4lxplained", doMeasure)
 
-    openocdproc = background_proc(tool_config['tools']['openocd'] + " -f board/atmel_sam4l8_xplained_pro.cfg")
-    gdb_launch(tool_config['tools']['arm_gdb'], 3333, fname, post_commands=["monitor shutdown"])
+    openocdproc = background_proc(tool_config['tools']['openocd'] +
+                                  " -f board/atmel_sam4l8_xplained_pro.cfg")
+    gdb_launch(tool_config['tools']['arm_gdb'], 3333, fname,
+               post_commands=["monitor shutdown"])
     kill_background_proc(openocdproc)
 
     return finishMeasurement("sam4lxplained", em, doMeasure)
@@ -518,6 +568,7 @@ def run_multiple(platformname, execname, repeats, measurement=True):
 
     return sum(measurements) / len(measurements)
 
+
 def main():
     arguments = docopt(__doc__)
 
@@ -525,7 +576,7 @@ def main():
 
     if arguments['--verbose'] == 1:
         logging.getLogger('').setLevel(logging.INFO)
-    elif arguments['--verbose']== 2:
+    elif arguments['--verbose'] == 2:
         logging.getLogger('').setLevel(logging.DEBUG)
 
     loadConfiguration(arguments['--config'])
@@ -536,34 +587,38 @@ def main():
         ms = []
         for i in range(int(arguments['--repeat'])):
             m = run(arguments['PLATFORM'],
-                arguments['EXECUTABLE'],
-                arguments['--no-measure'] is False)
+                    arguments['EXECUTABLE'],
+                    arguments['--no-measure'] is False)
             ms.append(m)
 
         m = sum(ms) / len(ms)
     except (IOError, RuntimeError) as e:
-        print "Error:",e
+        print "Error:", e
         quit(1)
 
     if arguments['--no-measure'] is False:
         if arguments['--csv']:
-            print "{m.energy}, {m.time}, {m.avg_power}, {m.avg_current}, {m.avg_voltage}".format(m=m)
+            print ("{m.energy}, {m.time}, {m.avg_power}, {m.avg_current}, "
+                   "{m.avg_voltage}").format(m=m)
         else:
-            if arguments['-s'] and hasattr(m,"measurements"):
+            if arguments['-s'] and hasattr(m, "measurements"):
 
                 s = "       "
                 for i in range(len(m.measurements)):
                     s += "           {}".format(i+1)
                 print s
 
-                names = ["Energy", "Time", "Power", "Average current", "Average voltage"]
-                keys = ["energy", "time", "avg_power", "avg_current", "avg_voltage"]
+                names = ["Energy", "Time", "Power", "Average current",
+                         "Average voltage"]
+                keys = ["energy", "time", "avg_power", "avg_current",
+                        "avg_voltage"]
                 units = ["J", "s", "W", "A", "V"]
 
-                for name,key,unit in zip(names, keys, units):
-                    print "{}:{}".format(name, " " *(15-len(name))),
+                for name, key, unit in zip(names, keys, units):
+                    print "{}:{}".format(name, " " * (15-len(name))),
                     for meas in m.measurements:
-                        print "{}{}".format(prettyPrint(meas.__dict__[key]), unit),
+                        print "{}{}".format(prettyPrint(meas.__dict__[key]),
+                                            unit),
                     print
 
             else:

--- a/pyenergy/src/platformrun/platformrun.py
+++ b/pyenergy/src/platformrun/platformrun.py
@@ -86,7 +86,7 @@ class LogWriter(object):
         pass
 
 
-class PlatformRun:
+class PlatformRun():
     def __init__(self):
         self.bg_procs = []
         self.bg_proc_map = {}
@@ -324,6 +324,17 @@ class PlatformRun:
         return ""
 
     #######################################################################
+
+    def __getattr__(self, name):
+        """
+            Handle old-style requests to self.platformname(...)
+        """
+        newname = 'platform_' + name
+        if newname in dir(PlatformRun):
+            attr = getattr(self, newname)
+            if callable(attr):
+                return attr
+        raise AttributeError
 
     def listPlatforms(self):
         print "Available platforms:"

--- a/pyenergy/src/platformrun/platformrun.py
+++ b/pyenergy/src/platformrun/platformrun.py
@@ -18,7 +18,7 @@ Options:
     --no-measure        Don't measure anything
     --csv               Print as csv
     -s                  Split energy measurements when board using multiple
-                        measurement points
+                        measurement points (overrides measurementrc)
 
     PLATFORM        Specify the platform on which to run.
 
@@ -577,12 +577,19 @@ def main():
         quit(1)
 
     if arguments['--no-measure'] is False:
+        global measurement_config
+        split = measurement_config[arguments['PLATFORM']].get('split', False)
         if arguments['--csv']:
-            print ("{m.energy}, {m.time}, {m.avg_power}, {m.avg_current}, "
-                   "{m.avg_voltage}").format(m=m)
+            if (arguments['-s'] or split) and hasattr(m, "measurements"):
+                for n, meas in enumerate(m.measurements):
+                    print (
+                        "{}, {m.energy}, {m.time}, {m.avg_power}, "
+                        "{m.avg_current}, {m.avg_voltage}").format(n+1, m=meas)
+            else:
+                print ("{m.energy}, {m.time}, {m.avg_power}, {m.avg_current}, "
+                       "{m.avg_voltage}").format(m=m)
         else:
-            if arguments['-s'] and hasattr(m, "measurements"):
-
+            if (arguments['-s'] or split) and hasattr(m, "measurements"):
                 s = "       "
                 for i in range(len(m.measurements)):
                     s += "           {}".format(i+1)

--- a/pyenergy/src/platformrun/platformrun.py
+++ b/pyenergy/src/platformrun/platformrun.py
@@ -200,10 +200,7 @@ class PlatformRun:
 
         proclogger = logger.getChild(cmd.split(' ')[0])
 
-        if collect:
-            logfile = None
-        else:
-            logfile = LogWriter(proclogger, logging.DEBUG)
+        logfile = LogWriter(proclogger, logging.DEBUG)
         proc = pexpect.spawn(cmd, logfile=logfile)
 
         proc.expect(pexpect.EOF)
@@ -347,7 +344,6 @@ class PlatformRun:
             ret = m, output
         else:
             ret = m
-        print collect, ret
         return ret
 
     @killBgOnCtrlC

--- a/pyenergy/src/pyenergy/interactive_graph.py
+++ b/pyenergy/src/pyenergy/interactive_graph.py
@@ -158,7 +158,7 @@ class Graph(QMainWindow):
             grid.setAlignment(Qt.AlignCenter)
 
             combo = QComboBox()
-            combo.addItems(["0.05", "0.5", "1", "5"])
+            combo.addItems(["0.05", "0.1", "0.5", "1", "5"])
             if mp == "Self":
                 combo.setCurrentIndex(1)
                 combo.setEnabled(False)
@@ -365,7 +365,7 @@ class Graph(QMainWindow):
         first_on = None
 
         for i, mp in enumerate(sorted(state.keys())):
-            self.em.measurement_params[i+1]['resistor'] = [0.05, 0.5, 1.0, 5.0][state[mp][0]]
+            self.em.measurement_params[i+1]['resistor'] = [0.05, 0.1, 0.5, 1.0, 5.0][state[mp][0]]
             stateChange = False
 
             # Check we need to enable or disable a measurement point


### PR DESCRIPTION
Because I didn't like the idea of maintaining a list of platforms and other arbitrary reasons, I updated platformrun to be a class, eliminating some globals and adding some magic.

It's _almost_ backwards compatible.

`import platformrun` can probably be replaced with `from platformrun import PlatformRun` and then in the appropriate place to `platformrun = PlatformRun()` so that existing calls still work. Note that I haven't actually tested this particular idea.
