### PR TITLE
Support newer matplotlib

### DIFF
--- a/pyenergy/src/pyenergy/interactive_graph.py
+++ b/pyenergy/src/pyenergy/interactive_graph.py
@@ -4,7 +4,11 @@ from PyQt4.QtGui import *
 
 import matplotlib
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+# Matplotlib version change leads to name change
+try:
+    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+except ImportError:
+    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
 from mpl_toolkits.axes_grid.parasite_axes import SubplotHost
 


### PR DESCRIPTION
Hi James,

On Ubuntu 16.04 matplotlib has changed some names within libraries. The fix is [simple](https://github.com/semiautomaticgit/SemiAutomaticClassificationPlugin/issues/2) and backwards compatible, so I have done it for  pyenergy.
